### PR TITLE
Bugfix of NunitTestRunner

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codecheck",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "codecheck CLI",
   "main": "src/codecheck.js",
   "scripts": {

--- a/src/tests/nunitTestRunner.js
+++ b/src/tests/nunitTestRunner.js
@@ -45,7 +45,7 @@ NUnitTestRunner.prototype.configure = function(yaml) {
     var added = false;
     for (var i=0; i<ret.length; i++) {
       if (ret[i].indexOf("-lib:") === 0) {
-        ret[i] += path.sep + monoPath;
+        ret[i] += "," + monoPath;
         added = true;
         break;
       }


### PR DESCRIPTION
If -lib option was specified in codecheck.yml, it didn't work.  
Because path separator is wrong.

@da0shi review me
FYI @NckHmml 