### PR TITLE
Improve npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codecheck",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "codecheck CLI",
   "main": "src/codecheck.js",
   "scripts": {

--- a/src/codecheckYaml.js
+++ b/src/codecheckYaml.js
@@ -96,7 +96,7 @@ CodecheckYaml.prototype.hasBuildCommand = function(str, strict) {
   });
 };
 
-CodecheckYaml.prototype.addBuildCommand = function(str) {
+CodecheckYaml.prototype.addBuildCommand = function(str, insertBefore) {
   if (!this.data.build) {
     this.data.build = [];
   }
@@ -105,7 +105,11 @@ CodecheckYaml.prototype.addBuildCommand = function(str) {
     value = [value];
     this.data.build = value;
   }
-  value.push(str);
+  if (insertBefore && value.indexOf(insertBefore) !== -1) {
+    value.splice(value.indexOf(insertBefore), 0, str);
+  } else {
+    value.push(str);
+  }
 };
 
 CodecheckYaml.prototype.getTestCommands = function() {

--- a/src/codecheckYaml.js
+++ b/src/codecheckYaml.js
@@ -77,8 +77,23 @@ CodecheckYaml.prototype.getBuildCommands = function() {
   return this.getAsArray("build");
 };
 
-CodecheckYaml.prototype.hasBuildCommand = function(str) {
-  return this.getBuildCommands().indexOf(str) !== -1;
+CodecheckYaml.prototype.hasBuildCommand = function(str, strict) {
+  function splitCommand(cmd) {
+    return cmd.match(/"[^"]*"|[^ ]+/g) || [];
+  }
+  var cmdArray = splitCommand(str);
+  return this.getBuildCommands().some(function(v) {
+    var cmdArray2 = splitCommand(v);
+    if (strict && cmdArray.length !== cmdArray2.length) {
+      return false;
+    }
+    for (var i=0; i<cmdArray.length; i++) {
+      if (cmdArray[i] !== cmdArray2[i]) {
+        return false;
+      }
+    }
+    return true;
+  });
 };
 
 CodecheckYaml.prototype.addBuildCommand = function(str) {

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -94,8 +94,8 @@ RunCommand.prototype.getConfig = function(dir) {
   if (fs.existsSync(codecheckYml)) {
     config.load(codecheckYml);
   }
-  if (fs.existsSync(packageJson) && !config.hasBuildCommand("npm install")) {
-    config.addBuildCommand("npm install");
+  if (fs.existsSync(packageJson) && !config.hasBuildCommand("npm")) {
+    config.addBuildCommand("npm install", config.getBuildCommands()[0]);
   }
   return config;
 };

--- a/test/codecheckYaml.test.js
+++ b/test/codecheckYaml.test.js
@@ -35,4 +35,48 @@ describe("CodecheckYaml", function() {
     assert.ok(config.hasBuildCommand("npm  install  --production", true), "allow multiple space when strict mode");
     assert.notOk(config.hasBuildCommand("npm install --hoge", true), "not match when strict mode");
   });
+
+});
+
+describe("addBuildCommand", function() {
+
+  it("add to last", function() {
+    var config = new CodecheckYaml();
+    assert.ok(config.load("test/testdata/buildtest.yml"));
+
+    config.addBuildCommand("hogehoge");
+    var commands = config.getBuildCommands();
+    assert.equal(commands.length, 4);
+    assert.equal(commands.indexOf("hogehoge"), 3);
+  });
+
+  it("add to head", function() {
+    var config = new CodecheckYaml();
+    assert.ok(config.load("test/testdata/buildtest.yml"));
+
+    config.addBuildCommand("hogehoge", config.getBuildCommands()[0]);
+    var commands = config.getBuildCommands();
+    assert.equal(commands.length, 4);
+    assert.equal(commands.indexOf("hogehoge"), 0);
+  });
+
+  it("add to middle", function() {
+    var config = new CodecheckYaml();
+    assert.ok(config.load("test/testdata/buildtest.yml"));
+
+    config.addBuildCommand("hogehoge", config.getBuildCommands()[1]);
+    var commands = config.getBuildCommands();
+    assert.equal(commands.length, 4);
+    assert.equal(commands.indexOf("hogehoge"), 1);
+  });
+
+  it("insert before undefined is equal to add to last", function() {
+    var config = new CodecheckYaml();
+    assert.ok(config.load("test/testdata/buildtest.yml"));
+
+    config.addBuildCommand("hogehoge", undefined);
+    var commands = config.getBuildCommands();
+    assert.equal(commands.length, 4);
+    assert.equal(commands.indexOf("hogehoge"), 3);
+  });
 });

--- a/test/codecheckYaml.test.js
+++ b/test/codecheckYaml.test.js
@@ -20,4 +20,19 @@ describe("CodecheckYaml", function() {
     assert.ok(config.getTestCommands()[0].indexOf("mocha") === 0);
 
   });
+
+  it("hasBuildCommand", function() {
+    var config = new CodecheckYaml();
+    assert.ok(config.load("test/testdata/buildtest.yml"));
+
+    assert.ok(config.hasBuildCommand("npm"), "match with partial command");
+    assert.ok(config.hasBuildCommand("npm install"), "match with partial command(2)");
+    assert.ok(config.hasBuildCommand("npm  install  --production"), "allow multiple space");
+    assert.notOk(config.hasBuildCommand("npm install --hoge"), "not match");
+
+    assert.notOk(config.hasBuildCommand("npm", true), "not match with partial command when strict mode");
+    assert.notOk(config.hasBuildCommand("npm install", true), "not match with partial command when strict mode(2)");
+    assert.ok(config.hasBuildCommand("npm  install  --production", true), "allow multiple space when strict mode");
+    assert.notOk(config.hasBuildCommand("npm install --hoge", true), "not match when strict mode");
+  });
 });

--- a/test/testdata/buildtest.yml
+++ b/test/testdata/buildtest.yml
@@ -1,0 +1,5 @@
+build:
+  - npm install --production
+  - babel es6/src --out-dir target
+  - babel es6/test --out-dir test
+test: mocha --harmony --timeout 600000


### PR DESCRIPTION
Refactor `npm install` handling in codecheck.yml.
This change makes some node challenge's performance better.

### Before
- If package.json is present in root and not exists `npm install` in build section, add `npm install` to build section.
- Added command is always placed at the last of build commands.(Bug)

### Changes
- Refactor CodecheckYaml#hasBuildCommand
  - Ignore multiple whitespace
  - Support partial compare
- Refactor addBuildCommand
  - Support insert before specified command
- Mod handling in run command
  - If some `npm` command is present in build, not to add `npm install`. (e.g. `npm install --production`)
  - Always add to head of build commands

@holycattle review me
FYI @takayukioda 
