### PR TITLE
Support singular in RSpecTestRunner

### DIFF
--- a/src/tests/noseTestRunner.js
+++ b/src/tests/noseTestRunner.js
@@ -22,7 +22,7 @@ function NoseTestRunner(args, cwd) {
       prev = data;
       return;
     }
-    var regex = /Ran (\d+) tests in/;
+    var regex = /Ran (\d+) tests? in/;
     var match = data.match(regex);
     if (match) {
       var allCount = parseInt(match[1]);

--- a/src/tests/rspecTestRunner.js
+++ b/src/tests/rspecTestRunner.js
@@ -8,7 +8,7 @@ var TestRunner = require("./testRunner");
  */
 function RSpecTestRunner(args, cwd) {
   function onStdout(data) {
-    var regex = /(\d+) examples, (\d+) failures/;
+    var regex = /(\d+) examples?, (\d+) failures?/;
     var match = data.match(regex);
     if (match) {
       self.failureCount = parseInt(match[2]);


### PR DESCRIPTION
The result output of RSpec might be singular.

You can verify this behavior with this challenge

https://github.com/code-check/fizzbuzz/tree/ruby

@holycattle review me
