### PR TITLE
Refactoring and Bugfix of ConsoleApp

### DIFF
--- a/src/app/abstractApp.js
+++ b/src/app/abstractApp.js
@@ -125,13 +125,12 @@ AbstractApp.prototype.run = function() {
       if (self.doClose) {
         self.doClose(code);
       }
-      resolve(code, self.stdoutAsArray(), self.stderrAsArray());
+      resolve([code, self.stdoutAsArray(), self.stderrAsArray()]);
     });
     p.on("error", function(err) {
       console.error("Error: " + self.cmd + " " + args.join(" "));
       console.error(err);
       reject(err);
-      throw err;
     });
   });
   self.childProcess = p;

--- a/src/app/abstractApp.js
+++ b/src/app/abstractApp.js
@@ -174,11 +174,14 @@ AbstractApp.prototype.storeStdout = function() {
   if (arguments.length === 0) {
     return this._storeStdout;
   }
-  if (arguments[0] === true) {
-    this._storeStdout = true;
+  var bStore = arguments[0];
+  if (bStore === this._storeStdout) {
+    return this;
+  }
+  this._storeStdout = bStore;
+  if (bStore) {
     this.emitter.on("stdout", doStore);
   } else {
-    this._storeStdout = false;
     this.emitter.off("stdout", doStore);
   }
   return self;
@@ -195,11 +198,14 @@ AbstractApp.prototype.storeStderr = function() {
   if (arguments.length === 0) {
     return this._storeStderr;
   }
-  if (arguments[0] === true) {
-    this._storeStderr = true;
+  var bStore = arguments[0];
+  if (bStore === this._storeSterr) {
+    return this;
+  }
+  this._storeStderr = bStore;
+  if (bStore) {
     this.emitter.on("stderr", doStore);
   } else {
-    this._storeStderr = false;
     this.emitter.off("stderr", doStore);
   }
   return self;

--- a/src/app/consoleApp.js
+++ b/src/app/consoleApp.js
@@ -30,12 +30,6 @@ ConsoleApp.prototype.expected = function() {
   return this;
 };
 
-ConsoleApp.prototype.doClose = function(code) {
-  if (this._consoleOut) {
-    process.stdout.write("codecheck: Finish '" + this.getCommandLine() + " with code " + code + "\n");
-  }
-};
-
 ConsoleApp.prototype.doRun = function(process) {
   process.stdin.setEncoding("utf-8");
   var values = this.input();

--- a/src/codecheck.js
+++ b/src/codecheck.js
@@ -11,7 +11,11 @@ function markdownTest(answers) {
   return new MarkdownTest(answers);
 }
 function consoleApp(cmd, cwd) {
-  return new ConsoleApp(cmd, cwd);
+  var app = new ConsoleApp(cmd, cwd);
+  app.consoleOut(true);
+  app.storeStdout(true);
+  app.storeStderr(true);
+  return app;
 }
 
 module.exports = {

--- a/test/app/calcApp.js
+++ b/test/app/calcApp.js
@@ -1,0 +1,27 @@
+"use strict";
+
+var a = parseInt(process.argv[2], 10);
+var b = parseInt(process.argv[3], 10);
+var op = process.argv[4] || "+";
+
+switch (op) {
+  case "+":
+    console.log(a + b);
+    break;
+  case "-":
+    console.log(a - b);
+    break;
+  case "*":
+    console.log(a * b);
+    break;
+  case "/":
+    console.log(a / b);
+    break;
+  case "%":
+    console.log(a % b);
+    break;
+  default:
+    console.log("Invalid op: " + op);
+}
+
+

--- a/test/app_store.test.js
+++ b/test/app_store.test.js
@@ -1,0 +1,84 @@
+"use strict";
+
+var assert = require("chai").assert;
+var ConsoleApp = require("../src/app/consoleApp");
+
+describe("ConsoleApp#storeStdout", function() {
+  it("should work", function() {
+    var app = new ConsoleApp("dummy");
+    assert.notOk(app.storeStdout());
+    app.storeStdout(true);
+    assert.ok(app.storeStdout());
+    for (let i=0; i<5; i++) {
+      app.emitter.emit("stdout", "a" + (i + 1));
+    }
+    assert.deepEqual(app.stdoutAsArray(), ["a1", "a2", "a3", "a4", "a5"]);
+  });
+
+  it("should not register EventListener twice", function() {
+    var app = new ConsoleApp("dummy");
+    assert.notOk(app.storeStdout());
+    app.storeStdout(true);
+    app.storeStdout(true);
+    assert.ok(app.storeStdout());
+    for (let i=0; i<5; i++) {
+      app.emitter.emit("stdout", "b" + (i + 1));
+    }
+    assert.deepEqual(app.stdoutAsArray(), ["b1", "b2", "b3", "b4", "b5"]);
+  });
+
+  it("should work with parameter `false`", function() {
+    var app = new ConsoleApp("dummy");
+    assert.notOk(app.storeStdout());
+    app.storeStdout(true);
+    assert.ok(app.storeStdout());
+    app.storeStdout(false);
+    assert.notOk(app.storeStdout());
+    app.storeStdout(true);
+    assert.ok(app.storeStdout());
+    for (let i=0; i<5; i++) {
+      app.emitter.emit("stdout", "c" + (i + 1));
+    }
+    assert.deepEqual(app.stdoutAsArray(), ["c1", "c2", "c3", "c4", "c5"]);
+  });
+});
+
+describe("ConsoleApp#storeStderr", function() {
+  it("should work", function() {
+    var app = new ConsoleApp("dummy");
+    assert.notOk(app.storeStderr());
+    app.storeStderr(true);
+    assert.ok(app.storeStderr());
+    for (let i=0; i<5; i++) {
+      app.emitter.emit("stderr", "a" + (i + 1));
+    }
+    assert.deepEqual(app.stderrAsArray(), ["a1", "a2", "a3", "a4", "a5"]);
+  });
+
+  it("should not register EventListener twice", function() {
+    var app = new ConsoleApp("dummy");
+    assert.notOk(app.storeStderr());
+    app.storeStderr(true);
+    app.storeStderr(true);
+    assert.ok(app.storeStderr());
+    for (let i=0; i<5; i++) {
+      app.emitter.emit("stderr", "b" + (i + 1));
+    }
+    assert.deepEqual(app.stderrAsArray(), ["b1", "b2", "b3", "b4", "b5"]);
+  });
+
+  it("should work with parameter `false`", function() {
+    var app = new ConsoleApp("dummy");
+    assert.notOk(app.storeStderr());
+    app.storeStderr(true);
+    assert.ok(app.storeStderr());
+    app.storeStderr(false);
+    assert.notOk(app.storeStderr());
+    app.storeStderr(true);
+    assert.ok(app.storeStderr());
+    for (let i=0; i<5; i++) {
+      app.emitter.emit("stderr", "c" + (i + 1));
+    }
+    assert.deepEqual(app.stderrAsArray(), ["c1", "c2", "c3", "c4", "c5"]);
+  });
+});

--- a/test/consoleApp.test.js
+++ b/test/consoleApp.test.js
@@ -66,7 +66,7 @@ describe("FizzBuzzApp", function() {
 
 describe("FizzBuzzApp", function() {
   it("with storeOutput", function(done) {
-    var app = codecheck.consoleApp(CMD, DIR)
+    var app = codecheck.consoleApp(CMD, DIR);
     app.storeStdout(true);
     app.input("1", "2", "3", "4", "5");
     app.onEnd(function() {

--- a/test/consoleApp.test.js
+++ b/test/consoleApp.test.js
@@ -84,3 +84,47 @@ describe("PromiseTest", function() {
     });
   });
 });
+
+describe("CalcApp", function() {
+  var app = codecheck.consoleApp("node test/app/calcApp.js");
+
+  it("should success with plus", function(done) {
+    app.run(3, 5).spread(function(code, stdout) {
+      assert.equal(code, 0);
+      assert.equal(stdout[0], 8);
+      done();
+    });
+  });
+
+  it("should success with minus", function(done) {
+    app.run(3, 5, "-").spread(function(code, stdout) {
+      assert.equal(code, 0);
+      assert.equal(stdout[0], -2);
+      done();
+    });
+  });
+
+  it("should success with mul", function(done) {
+    app.run(3, 5, "*").spread(function(code, stdout) {
+      assert.equal(code, 0);
+      assert.equal(stdout[0], 15);
+      done();
+    });
+  });
+
+  it("should success with div", function(done) {
+    app.run(12, 5, "/").spread(function(code, stdout) {
+      assert.equal(code, 0);
+      assert.equal(stdout[0], 2.4);
+      done();
+    });
+  });
+
+  it("should success with mod", function(done) {
+    app.run(3, 5, "%").spread(function(code, stdout) {
+      assert.equal(code, 0);
+      assert.equal(stdout[0], 3);
+      done();
+    });
+  });
+});

--- a/test/consoleApp.test.js
+++ b/test/consoleApp.test.js
@@ -64,15 +64,23 @@ describe("FizzBuzzApp", function() {
   });
 });
 
-describe("FizzBuzzApp", function() {
-  it("with storeOutput", function(done) {
+describe("PromiseTest", function() {
+  it("should success", function(done) {
     var app = codecheck.consoleApp(CMD, DIR);
-    app.storeStdout(true);
     app.input("1", "2", "3", "4", "5");
-    app.onEnd(function() {
-      assert.deepEqual(app.stdoutAsArray(), ["1", "2", "Fizz", "4", "Buzz"]);
+    app.run().spread(function(code, stdout) {
+      assert.equal(code, 0);
+      assert.deepEqual(stdout, ["1", "2", "Fizz", "4", "Buzz"]);
       done();
     });
-    app.run();
+  });
+
+  it("should fail", function(done) {
+    var app = codecheck.consoleApp("dummy");
+    app.input("1", "2", "3", "4", "5");
+    app.run().caught(function(err) {
+      assert(err);
+      done();
+    });
   });
 });


### PR DESCRIPTION
Bugfix
- some instance variables are not initialized
  - Move initialize code from constructor to init()
- storeStdout(storeStderr) might register same EventListener more than twice
  - by this code. `app.storeStdout(true); app.storeStdout(true);`
- storeStdout(false) doesn't work
  - because registered function instance is not same.

Refactoring
- AbstractApp#run returns promise

@takayukioda review me
