### PR TITLE
Versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codecheck",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "codecheck CLI",
   "main": "src/codecheck.js",
   "scripts": {

--- a/src/app/abstractApp.js
+++ b/src/app/abstractApp.js
@@ -23,6 +23,7 @@ AbstractApp.prototype.init = function() {
   this._consoleOut = false;
   this._storeStdout = false;
   this._storeStderr = false;
+  this._ignoreError = false;
   this._arrayStdout = [];
   this._arrayStderr = [];
 
@@ -131,8 +132,10 @@ AbstractApp.prototype.run = function() {
       resolve([code, self.stdoutAsArray(), self.stderrAsArray()]);
     });
     p.on("error", function(err) {
-      console.error("Error: " + self.cmd + " " + args.join(" "));
-      console.error(err);
+      if (!self._ignoreError) {
+        console.error("Error: " + self.cmd + " " + args.join(" "));
+        console.error(err);
+      }
       reject(err);
     });
   });
@@ -194,6 +197,15 @@ AbstractApp.prototype.doStoreFunc = function(key, bStore) {
     this.emitter.removeListener(key, func);
   }
   return self;
+};
+
+AbstractApp.prototype.ignoreError = function(b) {
+  if (typeof(b) === "undefined") {
+    return this._ignoreError;
+  } else {
+    this._ignoreError = b;
+    return this;
+  }
 };
 
 AbstractApp.prototype.doStoreToArray = function(arrayKey, value) {

--- a/src/cli/commandParser.js
+++ b/src/cli/commandParser.js
@@ -8,7 +8,8 @@ function convertShortOption(str) {
     "-e": "exam",
     "-p": "password",
     "-u": "user",
-    "-h": "host"
+    "-h": "host",
+    "-a": "all"
   };
   return options[str];
 }

--- a/src/cli/commandRepository.js
+++ b/src/cli/commandRepository.js
@@ -14,8 +14,7 @@ var repo = {
   clone: CloneCommand,
   pull: PullCommand,
   help: HelpCommand,
-  versions: VersionsCommand,
-  "-v": "versions"
+  versions: VersionsCommand
 };
 
 function CommandRepository() {

--- a/src/cli/commandRepository.js
+++ b/src/cli/commandRepository.js
@@ -1,18 +1,21 @@
 "use strict";
 
-var _             = require("lodash");
-var CloneCommand  = require("../commands/clone");
-var PullCommand   = require("../commands/pull");
-var RunCommand    = require("../commands/run");
-var ScoreCommand  = require("../commands/score");
-var HelpCommand   = require("../commands/help");
+var _               = require("lodash");
+var CloneCommand    = require("../commands/clone");
+var PullCommand     = require("../commands/pull");
+var RunCommand      = require("../commands/run");
+var ScoreCommand    = require("../commands/score");
+var HelpCommand     = require("../commands/help");
+var VersionsCommand = require("../commands/versions");
 
 var repo = {
   run: RunCommand,
   score: ScoreCommand,
   clone: CloneCommand,
   pull: PullCommand,
-  help: HelpCommand
+  help: HelpCommand,
+  versions: VersionsCommand,
+  "-v": "versions"
 };
 
 function CommandRepository() {
@@ -20,10 +23,16 @@ function CommandRepository() {
     return !!repo[name];
   }
   function getCommand(name) {
-    return repo[name];
+    var ret = repo[name];
+    if (typeof(ret) === "string") {
+      return getCommand(ret);
+    }
+    return ret;
   }
   function getCommandNames() {
-    return Object.keys(repo).sort();
+    return Object.keys(repo).filter(function(key) {
+      return typeof(repo[key]) === "function";
+    }).sort();
   }
   function isAPI(name) {
     return name === "clone" || name === "pull";

--- a/src/commands/versions.js
+++ b/src/commands/versions.js
@@ -7,8 +7,17 @@ var ConsoleApp        = require("../app/consoleApp");
 var commands = {
   "NodeJS": "node -v",
   "Ruby": "ruby -v",
-  "Java": "javaxxx -v",
-
+  "Python": "python --version",
+  "Python3": "python3 --version",
+  "Java": "java -version",
+  "Scala": "scala -version",
+  "Groovy": "groovy -v",
+  "Go": "go version",
+  "PHP": "php -v",
+  "Haskell": "ghc --version",
+  "Perl": "perl -v",
+  "C/C++": "gcc -dumpversion",
+  "C#": "mono --version"
 }
 
 function VersionsCommand() {

--- a/src/commands/versions.js
+++ b/src/commands/versions.js
@@ -1,0 +1,38 @@
+"use strict";
+
+var Promise           = require("bluebird");
+var CommandResult     = require("../cli/commandResult");
+
+var commands = {
+  "nodejs": "node -v",
+  "ruby": "ruby -v"
+}
+
+function VersionsCommand() {
+}
+
+VersionsCommand.prototype.getCommandRepository = function() {
+};
+
+VersionsCommand.prototype.shortHelp = function() {
+  return "Show versions";
+};
+
+VersionsCommand.prototype.usage = function() {
+  console.log("Show versions");
+  console.log("  codecheck versions");
+  console.log("  codecheck -v");
+};
+
+VersionsCommand.prototype.run = function(args) {
+  return new Promise(function(resolve) {
+    Object.keys(commands).forEach(function(key) {
+      var command = commands[key];
+      console.log(key, command);
+    });
+    resolve(new CommandResult(true));
+  });
+};
+
+
+module.exports = VersionsCommand;

--- a/src/commands/versions.js
+++ b/src/commands/versions.js
@@ -47,7 +47,6 @@ VersionsCommand.prototype.shortHelp = function() {
 VersionsCommand.prototype.usage = function() {
   console.log("Show versions");
   console.log("  codecheck versions");
-  console.log("  codecheck -v");
   console.log("OPTIONS");
   console.log("  -a, --all: Show frameworks version");
 };

--- a/src/commands/versions.js
+++ b/src/commands/versions.js
@@ -25,7 +25,7 @@ var frameworks = {
   "sbt": "sbt sbtVersion",
   "gradle": "gradle --version",
   "composer": "composer --version",
-  "nosestests": "nosetests --verison",
+  "nosestests": "nosetests --version",
   "mocha": "mocha --version",
   "PHPUnit": "phpunit --version",
   "bundler": "bundle --version",
@@ -72,7 +72,7 @@ VersionsCommand.prototype.process = function(category, map) {
     return app.run().spread(function(code, stdout, stderr) {
       if (stdout) stdout.forEach(v => console.log(v));
       if (stderr) stderr.forEach(v => console.log(v));
-      return supported + 1;
+      return code === 0 ? supported + 1 : supported;
     }).catch(function() {
       console.log("Not supported");
       return supported;

--- a/src/commands/versions.js
+++ b/src/commands/versions.js
@@ -18,7 +18,7 @@ var languages = {
   "Perl": "perl -v",
   "C/C++": "gcc -dumpversion",
   "C#": "mono --version"
-}
+};
 
 var frameworks = {
   "maven": "mvn -v",
@@ -32,7 +32,7 @@ var frameworks = {
   "cabal": "cabal --version",
   "prove": "prove --version",
   "rspec": "rspec --version"
-}
+};
 
 function VersionsCommand() {
 }
@@ -80,7 +80,7 @@ VersionsCommand.prototype.process = function(category, map) {
   }, 0).then(function(supported) {
     console.log(supported + " " + category + " are supported.");
     return new CommandResult(true);
-  })
-}
+  });
+};
 
 module.exports = VersionsCommand;


### PR DESCRIPTION
- Add `versions` command to codecheck 
- Update version to 0.5.4

This is command result of current docker image.

@takayukioda review me
FYI @shok4a 

``` bash
codecheck version 0.5.3
[NodeJS]
v4.4.3
[Ruby]
ruby 2.2.4p230 (2015-12-16 revision 53155) [x86_64-linux-gnu]
[Python]
Python 2.7.6
[Python3]
Python 3.4.3
[Java]
java version "1.8.0_77"
Java(TM) SE Runtime Environment (build 1.8.0_77-b03)
Java HotSpot(TM) 64-Bit Server VM (build 25.77-b03, mixed mode)
[Scala]
Scala code runner version 2.11.7 -- Copyright 2002-2013, LAMP/EPFL
[Groovy]
Groovy Version: 2.4.5 JVM: 1.8.0_77 Vendor: Oracle Corporation OS: Linux
[Go]
go version go1.4.2 linux/amd64
[PHP]
PHP 5.6.20-1+deb.sury.org~trusty+1 (cli) 
Copyright (c) 1997-2016 The PHP Group
Zend Engine v2.6.0, Copyright (c) 1998-2016 Zend Technologies
    with Zend OPcache v7.0.6-dev, Copyright (c) 1999-2016, by Zend Technologies
[Haskell]
The Glorious Glasgow Haskell Compilation System, version 7.6.3
[Perl]

This is perl 5, version 18, subversion 2 (v5.18.2) built for x86_64-linux-gnu-thread-multi
(with 44 registered patches, see perl -V for more detail)

Copyright 1987-2013, Larry Wall

Perl may be copied only under the terms of either the Artistic License or the
GNU General Public License, which may be found in the Perl 5 source kit.

Complete documentation for Perl, including FAQ lists, should be found on
this system using "man perl" or "perldoc perl".  If you have access to the
Internet, point your browser at http://www.perl.org/, the Perl Home Page.

[C/C++]
4.8
[C#]
Mono JIT compiler version 3.2.8 (Debian 3.2.8+dfsg-4ubuntu1.1)
Copyright (C) 2002-2014 Novell, Inc, Xamarin Inc and Contributors. www.mono-project.com
	TLS:           __thread
	SIGSEGV:       altstack
	Notifications: epoll
	Architecture:  amd64
	Disabled:      none
	Misc:          softdebug 
	LLVM:          supported, not enabled.
	GC:            sgen
13 languages are supported.
```
