### PR TITLE
Add linefeed before codecheck output

### DIFF
--- a/src/tests/testRunner.js
+++ b/src/tests/testRunner.js
@@ -27,7 +27,7 @@ TestRunner.prototype.getExecuteCount = function() {
 
 TestRunner.prototype.doClose = function(code) {
   if (this._consoleOut) {
-    process.stdout.write("codecheck: Finish with code " + code + "\n");
+    process.stdout.write("\ncodecheck: Finish with code " + code + "\n");
     process.stdout.write("codecheck: tests  : " + this.getExecuteCount() + "\n");
     process.stdout.write("codecheck: success: " + this.getSuccessCount() + "\n");
     process.stdout.write("codecheck: failure: " + this.getFailureCount() + "\n");


### PR DESCRIPTION
Add linefeed before writing codecheck final messages.
Because executed app might not output last linefeed.  
In this case, output layout will be broken.

@takayukioda review me