### PR TITLE
Quoted args

### DIFF
--- a/src/app/abstractApp.js
+++ b/src/app/abstractApp.js
@@ -73,7 +73,7 @@ AbstractApp.prototype.normalizeArgs = function(args) {
 };
 
 AbstractApp.prototype.getCommandLine = function() {
-  return this.cmd + " " + this.args.join(" ");
+  return shellQuote.quote([this.cmd].concat(this.args));
 };
 
 AbstractApp.prototype.consoleOut = function() {

--- a/src/tests/testUtils.js
+++ b/src/tests/testUtils.js
@@ -69,8 +69,8 @@ function createTestRunner(name, args, cwd) {
       return new NUnitTestRunner(args, cwd);
     default:
   }
-  var cmd = [name].concat(args).join(" ");
-  var runner = new TestRunner(cmd, cwd);
+  var runner = new TestRunner(name, cwd);
+  runner.args = args;
   runner.onStdout(function(data) {
     commonTestCounter(runner, data);
   });

--- a/test/quoted-args/codecheck.yml
+++ b/test/quoted-args/codecheck.yml
@@ -1,0 +1,1 @@
+test: node index.js aaa bbb "ccc ddd"

--- a/test/quoted-args/index.js
+++ b/test/quoted-args/index.js
@@ -1,0 +1,1 @@
+process.argv.slice(2).forEach(v => console.log(v));


### PR DESCRIPTION
#76 and #77 

codecheck.yml for test is in test/quoted-args.

Before
```
$ ../../bin/codecheck
codecheck version 0.6.4
codecheck: testCommand: node index.js aaa bbb ccc ddd
aaa
bbb
ccc
ddd
```

After
```
$ ../../bin/codecheck
codecheck version 0.6.4
codecheck: testCommand: node index.js aaa bbb 'ccc ddd'
aaa
bbb
ccc ddd
```

Though quote symbol is changed from `"` to `'`, it is not a matter.

Also, I've verified it works with ChallengeViewer debug feature.

@takayukioda review me