### PR TITLE
Ignore stdin error on run

### DIFF
--- a/src/app/consoleApp.js
+++ b/src/app/consoleApp.js
@@ -32,6 +32,9 @@ ConsoleApp.prototype.expected = function() {
 };
 
 ConsoleApp.prototype.doRun = function(process) {
+  process.stdin.on("error", e => {
+      // ignore
+  });
   process.stdin.setEncoding("utf-8");
   var values = this.input();
   while (values.length) {

--- a/src/app/consoleApp.js
+++ b/src/app/consoleApp.js
@@ -32,7 +32,7 @@ ConsoleApp.prototype.expected = function() {
 };
 
 ConsoleApp.prototype.doRun = function(process) {
-  process.stdin.on("error", e => {
+  process.stdin.on("error", () => {
       // ignore
   });
   process.stdin.setEncoding("utf-8");


### PR DESCRIPTION
https://github.com/code-check/codecheck/issues/88

顧客企業が標準入力からデータを受け取るカスタムチャレンジを作成した時に発覚したバグ。
標準入力を読み切る前にアプリが強制終了すると固まる。

この時はチャレンジ側で`doRun`メソッドを置き換えることで対応した。

ちなみに、現時点ではtrackのpresetsで標準入力からデータを受け取るチャレンジはない

@takayukioda review