### PR TITLE
Use index access instead of Array#shift

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codecheck",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "codecheck CLI",
   "main": "src/codecheck.js",
   "scripts": {

--- a/src/app/consoleApp.js
+++ b/src/app/consoleApp.js
@@ -42,8 +42,8 @@ ConsoleApp.prototype.doRun = function(process) {
   });
   process.stdin.setEncoding("utf-8");
   var values = this.input();
-  while (values.length) {
-    var value = values.shift();
+  for (var i=0; i<values.length; i++) {
+    var value = values[i];
     process.stdin.write(value + "\n");
   }
   process.stdin.end();

--- a/test/test_runner/testRunner.test.js
+++ b/test/test_runner/testRunner.test.js
@@ -78,9 +78,14 @@ describe("TestRunner", function() {
       const settings = Object.assign({
         language: "ja"
       }, require("./menial-attack/test/settings.stdin.json"));
-      settings.input.type = "arguments";
-      settings.input.source = "raw";
-      settings.output.source = "raw";
+      settings.input = {
+        type: "arguments",
+        source: "raw"
+      };
+      settings.output = {
+        type: "stdout",
+        source: "raw"
+      };
       const testcases = require("./menial-attack/test/basic_testcases.json").map(v => {
         const input = fs.readFileSync("./test/test_runner/menial-attack/test/" + v.input, "utf-8");
         const output = fs.readFileSync("./test/test_runner/menial-attack/test/" + v.output, "utf-8");


### PR DESCRIPTION
https://github.com/code-check/codecheck/issues/95

I've run GREP `shift()` with all source code.
As a result, we have to fix is only stdin handling.

About fix for `testRunner.test.js`.
Object#assign doesn't copy child object.
So, if `require("./menial-attack/test/settings.stdin.json")` is used in other place, it breaks original json.

@bschwind review me