### PR TITLE
Improve TestRunner

### DIFF
--- a/src/test_runner/settings.js
+++ b/src/test_runner/settings.js
@@ -113,10 +113,7 @@ class Settings {
   outputType() { return this.json.output.type; }
   outputSource() { return this.json.output.source || DataSource.File; }
   outputFilename() { 
-    if (this.outputType() === OutputType.File || this.hasJudge()) {
-      return this.json.output.filename || DEFAULT_OUTPUT_FILENAME;
-    }
-    return null;
+    return this.json.output.filename || DEFAULT_OUTPUT_FILENAME;
   }
 
   hasJudge() { return !!(this.json.judge && this.json.judge.command); }

--- a/src/test_runner/stringData.js
+++ b/src/test_runner/stringData.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const fs = require("fs");
+
 function splitStrByLine(str) {
   return str.split(/\n/).filter(v => v.length > 0);
 }
@@ -10,27 +12,86 @@ function splitStrBySpace(str) {
 
 
 class StringData {
-  constructor(raw) {
+  constructor(filename, raw) {
+    this._filename = filename;
     this._raw = raw;
   }
 
-  raw() { return this._raw; }
-  lines() { return splitStrByLine(this._raw); }
-  tokens() { return splitStrBySpace(this._raw); }
+  raw() { 
+    if (!this._raw && this._filename) {
+      this._raw = fs.readFileSync(this._filename, "utf-8");
+    }
+    return this._raw; 
+  }
+
+  length() {
+    if (this._raw) {
+      return this._raw.length;
+    }
+    if (this._filename) {
+      return fs.statSync(this._filename).size;
+    }
+    return 0;
+  }
+
+  lines() { return splitStrByLine(this.raw()); }
+  tokens() { return splitStrBySpace(this.raw()); }
+  filename() { return this._filename; }
+
+  // clip(maxLen, maxLines) {
+  //   let result = "";
+  //   let omitted = false;
+  //   if (this._raw) {
+  //     const str = this._raw;
+  //     let array = splitStrByLine(str);
+  //     if (array.length > maxLines) {
+  //       array = array.slice(0, maxLines);
+  //       omitted = true;
+  //     }
+  //     result = array.join("\n");
+  //   }
+  //   if (this._filename) {
+  //     let line = null;
+  //     let count = 0;
+  //     const reader = new LineByLine(this._filename);
+  //     while (line = reader.next()) {
+  //       result += line.toString("utf8") + "\n";
+  //       count++;
+  //       if (count >= maxLines || result.length > maxLen) {
+  //         omitted = true;
+  //         break;
+  //       } 
+  //     }
+  //     reader.close();
+  //   }
+  //   if (result.length > maxLen) {
+  //     result = result.substring(0, maxLen);
+  //     omitted = true;
+  //   }
+  //   if (omitted) {
+  //     result += "...";
+  //   }
+  //   return result;
+  // }
+}
+
+function fromFile(filename) {
+  return new StringData(filename, null);
 }
 
 function fromRaw(raw) {
-  return new StringData(raw);
+  return new StringData(null, raw);
 }
 
 function fromLines(lines) {
   const raw = lines.join("\n");
-  return new StringData(raw);
+  return new StringData(null, raw);
 }
 
 module.exports = {
   splitStrByLine,
   splitStrBySpace,
   fromRaw,
-  fromLines
+  fromLines,
+  fromFile
 };

--- a/src/test_runner/stringData.js
+++ b/src/test_runner/stringData.js
@@ -38,41 +38,6 @@ class StringData {
   tokens() { return splitStrBySpace(this.raw()); }
   filename() { return this._filename; }
 
-  // clip(maxLen, maxLines) {
-  //   let result = "";
-  //   let omitted = false;
-  //   if (this._raw) {
-  //     const str = this._raw;
-  //     let array = splitStrByLine(str);
-  //     if (array.length > maxLines) {
-  //       array = array.slice(0, maxLines);
-  //       omitted = true;
-  //     }
-  //     result = array.join("\n");
-  //   }
-  //   if (this._filename) {
-  //     let line = null;
-  //     let count = 0;
-  //     const reader = new LineByLine(this._filename);
-  //     while (line = reader.next()) {
-  //       result += line.toString("utf8") + "\n";
-  //       count++;
-  //       if (count >= maxLines || result.length > maxLen) {
-  //         omitted = true;
-  //         break;
-  //       } 
-  //     }
-  //     reader.close();
-  //   }
-  //   if (result.length > maxLen) {
-  //     result = result.substring(0, maxLen);
-  //     omitted = true;
-  //   }
-  //   if (omitted) {
-  //     result += "...";
-  //   }
-  //   return result;
-  // }
 }
 
 function fromFile(filename) {

--- a/src/test_runner/testRunner.js
+++ b/src/test_runner/testRunner.js
@@ -71,7 +71,7 @@ class TestRunner {
         }
         const result = await app.codecheck(inputParams.arguments);
         const outputData = StringData.fromFile(settings.outputFilename());
-        await self.verifyStatusCode(testcase, inputData, outputData, result, );
+        await self.verifyStatusCode(testcase, inputData, outputData, result);
 
         if (settings.outputType() === OutputType.File) {
           // Verify outputFile exists 

--- a/src/test_runner/testRunner.js
+++ b/src/test_runner/testRunner.js
@@ -11,7 +11,7 @@ const OutputType = require("./outputType");
 const JudgeType = require("./judgeType");
 const DataSource = require("./dataSource");
 const Testcase = require("./testcase");
-const FileComparator = require("./fileComparator");
+const TokenComparator = require("./tokenComparator");
 
 class TestRunner {
   constructor(settings, appCommand) {
@@ -22,8 +22,6 @@ class TestRunner {
 
   consoleApp(cmd, cwd) {
     var app = new ConsoleApp(cmd, cwd);
-    app.consoleOut(true);
-    app.storeStdout(true);
     app.storeStderr(true);
     app.consoleOut(false);
     app.storeStdMax(2000000);
@@ -63,9 +61,17 @@ class TestRunner {
         if (inputParams.stdin.length > 0) {
           app.input(inputParams.stdin);
         }
+        if (inputParams.filename) {
+          app.inputFile(inputParams.filename);
+        }
+        if (settings.outputType() === OutputType.StdOut) {
+          app.stdoutFile(settings.outputFilename());
+        } else {
+          app.storeStdout(true);
+        }
         const result = await app.codecheck(inputParams.arguments);
-        const outputData = StringData.fromLines(result.stdout);
-        await self.verifyStatusCode(testcase, inputData, result);
+        const outputData = StringData.fromFile(settings.outputFilename());
+        await self.verifyStatusCode(testcase, inputData, outputData, result, );
 
         if (settings.outputType() === OutputType.File) {
           // Verify outputFile exists 
@@ -74,26 +80,21 @@ class TestRunner {
           } catch (e) {
             assert.fail(await MSG.noOutputFile());
           }
-        } else if (settings.hasJudge()) {
-          // If it uses judge and not File type, make outputFile.
-          fs.writeFileSync(settings.outputFilename(), outputData.raw(), "utf-8");
         }
 
         if (settings.hasJudge()) {
           await self.verifyByJudge(testcase, inputData, outputData);
-        } else if (settings.outputType() === OutputType.StdOut) {
-          await self.verifyStdout(testcase, inputData, outputData);
-        } else {// settings.outputType() === OutputType.File
+        } else {
           await self.verifyOutputFile(testcase, inputData, outputData);
         }
       });
     });
   }
 
-  async verifyStatusCode(testcase, inputData, result) {
+  async verifyStatusCode(testcase, inputData, outputData, result) {
     const MSG = this.messageBuilder;
     if (result.code !== 0) {
-      console.log(await MSG.abnormalEnd(inputData, result));
+      console.log(await MSG.abnormalEnd(inputData, outputData, result));
       assert.fail(await MSG.nonZeroStatusCode());
     }
   }
@@ -123,6 +124,7 @@ class TestRunner {
   async verifyByDefaultJudge(testcase, inputData, outputData) {
     const MSG = this.messageBuilder;
     const judge = this.consoleApp(this.settings.judgeCommand());
+    judge.storeStdout(true);
     const arg1 = testcase.input();               // Filename of input data.
     const arg2 = testcase.output() || "null";    // Filename of expect output. (It may not exist)
     const arg3 = this.settings.outputFilename(); // Filename of user outoput.
@@ -154,10 +156,11 @@ class TestRunner {
   async verifyByAOJJudge(testcase, inputData, outputData) {
     const MSG = this.messageBuilder;
     const judge = this.consoleApp(this.settings.judgeCommand());
+    judge.storeStdout(true);
     const arg1 = testcase.input();               // Filename of input data.
     const arg2 = this.settings.outputFilename(); // Filename of user outoput.
     const arg3 = testcase.output() || "null";    // Filename of expect output. (It may not exist)
-    judge.input(outputData.lines()); // Pass user output to stdin. 
+    judge.inputFile(outputData.filename()); // Pass user output to stdin. 
     const result = await judge.codecheck([arg1, arg2, arg3]);
     if (result.code === 0 && result.stdout.length === 0) {
       return;
@@ -165,39 +168,15 @@ class TestRunner {
     assert.fail(result.stdout.join("\n") + "\n" + (await MSG.summary(testcase, inputData, outputData)));
   }
 
-  async verifyStdout(testcase, inputData, outputData) {
-    const MSG = this.messageBuilder;
-    const expected = this.calcExpected(testcase, inputData).tokens();
-    const users = outputData.tokens();
-
-    if (expected.length !== users.length) {
-      assert.fail(await MSG.invalidDataLength(testcase, inputData, outputData, expected.length, users.length));
-    }
-    for (let i=0; i<expected.length; i++) {
-      const expected_token = expected[i];
-      const user_token = users[i];
-      if (!this.compareToken(expected_token, user_token)) {
-        assert.fail(null, null, await MSG.unmatchToken(testcase, outputData, i + 1, expected_token, user_token));
-      }
-    }
-  }
-
   async verifyOutputFile(testcase, inputData, outputData) {
     const MSG = this.messageBuilder;
-    const comparator = new FileComparator();
-    const result = await(comparator.compare(testcase.output(), this.settings.outputFilename()));
+    const comparator = new TokenComparator(this.settings.eps());
+    const result = this.settings.outputSource() === DataSource.Raw ?
+      comparator.compareStrings(testcase.output(), outputData.raw()) :      
+      await(comparator.compareFiles(testcase.output(), outputData.filename()));
     if (result.index !== -1) {
-      assert.fail(await MSG.unmatchToken(testcase, outputData, result.index, result.file1, result.file2));
+      assert.fail(await MSG.unmatchToken(testcase, inputData, outputData, result.index, result.token1, result.token2));
     }
-  }
-
-  compareToken(token1, token2) {
-    if (this.settings.hasEps()) {
-      const n1 = Number(token1);
-      const n2 = Number(token2);
-      return Math.abs(n1 - n2) <= this.settings.eps();
-    }
-    return token1 === token2;
   }
 
   beforeEach(done) {
@@ -227,7 +206,7 @@ class TestRunner {
   createInput(testcase) {
     switch (this.settings.inputSource()) {
       case DataSource.File:
-        return StringData.fromRaw(testcase.readInputFromFile());
+        return StringData.fromFile(testcase.input());
       case DataSource.Raw:
         return StringData.fromRaw(testcase.input());
       default:
@@ -236,14 +215,19 @@ class TestRunner {
   }
 
   prepareInput(testcase, inputData) {
+    let filename = null;
     let stdin = [];
     let args = [];
     switch (this.settings.inputType()) {
       case InputType.File:
-        args = testcase.input();
+        args = inputData.filename();
         break;
       case InputType.StdIn:
-        stdin = inputData.lines();
+        if (this.settings.inputSource() === DataSource.Raw) {
+          stdin = inputData.lines();
+        } else {
+          filename = inputData.filename();
+        }
         break;
       case InputType.Arguments:
         args = inputData.tokens();
@@ -252,6 +236,7 @@ class TestRunner {
         throw new Error("Unknown input type: " + this.settings.inputType());
     }
     return {
+      filename: filename,
       stdin: stdin,
       arguments: args
     };
@@ -261,7 +246,7 @@ class TestRunner {
     /* eslint no-unused-vars: 0 */
     switch (this.settings.outputSource()) {
       case DataSource.File:
-        return StringData.fromRaw(testcase.readOutputFromFile());
+        return StringData.fromFile(testcase.output());
       case DataSource.Raw:
         return StringData.fromRaw(testcase.output());
       default:

--- a/src/test_runner/tokenComparator.js
+++ b/src/test_runner/tokenComparator.js
@@ -9,7 +9,7 @@ class TokenComparator {
     this.eps = eps || -1;
   }
 
-  compareToken(token1, token2) {
+  compareTokens(token1, token2) {
     if (this.eps > 0) {
       const n1 = Number(token1);
       const n2 = Number(token2);
@@ -31,7 +31,7 @@ class TokenComparator {
     }
     let index = 0;
     while (index < len) {
-      if (!this.compareToken(tokens1[index], tokens2[index])) {
+      if (!this.compareTokens(tokens1[index], tokens2[index])) {
         return {
           index: index + 1,
           token1: tokens1[index],
@@ -63,7 +63,7 @@ class TokenComparator {
             index++;
             const a = tokens1.shift();
             const b = tokens2.shift();
-            if (!self.compareToken(a, b)) {
+            if (!self.compareTokens(a, b)) {
               forceClose(index, a, b);
               return false;
             }

--- a/src/test_runner/tokenComparator.js
+++ b/src/test_runner/tokenComparator.js
@@ -2,9 +2,50 @@
 
 const fs = require("fs");
 const readline = require("readline");
+const StringData = require("./stringData");
 
-class FileComparator {
-  compare(filepath1, filepath2) {
+class TokenComparator {
+  constructor(eps) {
+    this.eps = eps || -1;
+  }
+
+  compareToken(token1, token2) {
+    if (this.eps > 0) {
+      const n1 = Number(token1);
+      const n2 = Number(token2);
+      return Math.abs(n1 - n2) <= this.eps;
+    }
+    return token1 === token2;
+  }
+
+  compareStrings(str1, str2) {
+    const tokens1 = StringData.fromRaw(str1).tokens();
+    const tokens2 = StringData.fromRaw(str2).tokens();
+    const len = Math.min(tokens1.length, tokens2.length);
+    if (tokens1.length !== tokens2.length) {
+      return {
+        index: len,
+        token1: tokens1[len - 1],
+        token2: tokens2[len - 1]
+      };
+    }
+    let index = 0;
+    while (index < len) {
+      if (!this.compareToken(tokens1[index], tokens2[index])) {
+        return {
+          index: index + 1,
+          token1: tokens1[index],
+          token2: tokens2[index]
+        }
+      }
+      index++;
+    }
+    return {
+      index: -1
+    };
+  }
+  compareFiles(filepath1, filepath2) {
+    const self = this;
     const tokens1 = [];
     const tokens2 = [];
     let index = 0;
@@ -22,7 +63,7 @@ class FileComparator {
             index++;
             const a = tokens1.shift();
             const b = tokens2.shift();
-            if (a !== b) {
+            if (!self.compareToken(a, b)) {
               forceClose(index, a, b);
               return false;
             }
@@ -40,8 +81,8 @@ class FileComparator {
           }
           resolve({
             index, 
-            file1: a,
-            file2: b
+            token1: a,
+            token2: b
           });
         }
         function doClose() {
@@ -53,8 +94,8 @@ class FileComparator {
             } else {
               resolve({
                 index: index + 1,
-                file1: tokens1.shift(),
-                file2: tokens2.shift()
+                token1: tokens1.shift(),
+                token2: tokens2.shift()
               });
             }
           }
@@ -90,4 +131,4 @@ class FileComparator {
   }
 }
 
-module.exports = FileComparator;
+module.exports = TokenComparator;

--- a/test/fileComparator.test.js
+++ b/test/fileComparator.test.js
@@ -1,31 +1,31 @@
 "use strict";
 
 var assert = require("chai").assert;
-var FileComparator = require("../src/test_runner/fileComparator");
+var TokenComparator = require("../src/test_runner/tokenComparator");
 
-describe("FileComparator", function() {
+describe("TokenComparator", function() {
 
   it("should succeed with same file.", async () => {
-    const comparator = new FileComparator();
-    const result = await comparator.compare("test/file_comparator_data/abc1.txt", "test/file_comparator_data/abc1.txt");
+    const comparator = new TokenComparator();
+    const result = await comparator.compareFiles("test/file_comparator_data/abc1.txt", "test/file_comparator_data/abc1.txt");
     assert.equal(result.index, -1);
   });
 
   it("should succeed with different file.(1)", async () => {
-    const comparator = new FileComparator();
-    const result = await comparator.compare("test/file_comparator_data/abc1.txt", "test/file_comparator_data/abc2.txt");
+    const comparator = new TokenComparator();
+    const result = await comparator.compareFiles("test/file_comparator_data/abc1.txt", "test/file_comparator_data/abc2.txt");
     assert.equal(result.index, 5);
   });
 
   it("should succeed with different file.(2)", async () => {
-    const comparator = new FileComparator();
-    const result = await comparator.compare("test/file_comparator_data/abc1.txt", "test/file_comparator_data/abc3.txt");
+    const comparator = new TokenComparator();
+    const result = await comparator.compareFiles("test/file_comparator_data/abc1.txt", "test/file_comparator_data/abc3.txt");
     assert.equal(result.index, 10);
   });
 
   it("should succeed with different file.(3)", async () => {
-    const comparator = new FileComparator();
-    const result = await comparator.compare("test/file_comparator_data/abc3.txt", "test/file_comparator_data/abc1.txt");
+    const comparator = new TokenComparator();
+    const result = await comparator.compareFiles("test/file_comparator_data/abc3.txt", "test/file_comparator_data/abc1.txt");
     assert.equal(result.index, 10);
   });
 });

--- a/test/test_runner/testRunner.test.js
+++ b/test/test_runner/testRunner.test.js
@@ -5,7 +5,7 @@ const codecheck = require("../../src/codecheck");
 
 describe("TestRunner", function() {
   describe("input = arguments, output = stdout", function() {
-    describe("menial-attack - all pass", function() {
+    describe("menial-attack - all pass(25/25", function() {
       const settings = Object.assign({
         baseDirectory: "test/test_runner/menial-attack/test",
         language: "ja"
@@ -16,7 +16,7 @@ describe("TestRunner", function() {
       runner.runAll(testcases);
     });
 
-    describe("menial-attack - partial pass", function() {
+    describe("menial-attack - partial pass(19/25)", function() {
       const settings = Object.assign({
         baseDirectory: "test/test_runner/menial-attack/test",
         language: "ja"
@@ -29,7 +29,7 @@ describe("TestRunner", function() {
   });
 
   describe("input = stdin, output = stdout", function() {
-    describe("menial-attack - all pass", function() {
+    describe("menial-attack - all pass(25/25)", function() {
       const settings = Object.assign({
         baseDirectory: "test/test_runner/menial-attack/test",
         language: "ja"
@@ -39,11 +39,10 @@ describe("TestRunner", function() {
 
       runner.runAll(testcases);
     });
-
   });
 
   describe("input = file, output = file", function() {
-    describe("menial-attack - all pass", function() {
+    describe("menial-attack - all pass(25/25)", function() {
       const settings = Object.assign({
         baseDirectory: "test/test_runner/menial-attack/test",
         language: "ja"
@@ -57,7 +56,7 @@ describe("TestRunner", function() {
   });
 
   describe("with raw", function() {
-    describe("menial-attack - with raw", function() {
+    describe("menial-attack - with raw - partial pass(19/25)", function() {
       const settings = Object.assign({
         language: "ja"
       }, require("./menial-attack/test/settings.stdin.json"));
@@ -85,7 +84,7 @@ describe("TestRunner", function() {
   });
 
   describe("with infinite loop", function() {
-    describe("menial-attack - infinite loop", function() {
+    describe("menial-attack - infinite loop - all fail(5/5)", function() {
       const settings = Object.assign({
         baseDirectory: "test/test_runner/menial-attack/test",
         language: "ja"


### PR DESCRIPTION
@takayukioda review me roughly

## ConsoleApp
ConsoleAppに対して入出力をファイル経由で設定・取得するオプションを追加
- inputFile: 指定された場合、そのファイルの内容を実行するCLIアプリの標準入力に引き渡す
  - ファイルはLine by Lineで読み込まれるのでTestRuner側ではメモリを消費しない
  - CLIアプリ側では標準のテンプレートコードを使う場合は一度オンメモリに全データが載る
  - 受験者が標準入力の読み込みの部分を自分でカスタマイズして省メモリで実行できるようにすることは可能
- stdoutFile: 指定された場合、標準出力の内容が指定のファイルに保存される
  - この設定はstoreStdoutの設定とは独立している。
  - つまりstoreStdoutはfalseにしないとやはり標準出力の内容はオンメモリに保存される
- stderrFile: 指定された場合、標準エラー出力の内容が指定のファイルに保存される
  - 同様にstoreStderrの設定とは独立している。

## MessageBuilder
MessageBuilderはエラーメッセージを組み立てているクラス
この中で入力データ、期待する出力、ユーザ出力などをメッセージに組み込んでいるが巨大な場合、それらはclipされる。

これまでは入出力データはほぼオンメモリに載っていたのでclipもオンメモリで行われていたが、極力ファイルからクリップするように修正した

## Settings
outputFilenameはoutputSourceがFileの場合か、judgeがある場合以外はnullを返していたが常に非nullの値を返すように修正した。
(実際の運用ではデフォルトの`answer.txt`から変更されることはあまりないと思われる。)

## StringData
ファイル名から作成するファクトリを追加。
ファイルから作成する場合は遅延読み込みとなるので`raw()`または`lines()`メソッドを呼び出さない限りファイルの内容がオンメモリに載ることはない

## FileComparator -(rename)-> TokenComparator
- TestRunner上にあったString同士を比較するメソッドをこちらに移動(`compareStrings`)
- epsに対応

## TestRunner
- 標準入力へのデータの引き渡しはファイル経由のLine by Lineとした
- 標準出力の内容はオンメモリに保存せずファイルに保存するようにした
  - ただし、元々ファイル作成を要求する問題の場合(Settings#outputType == File)の場合は、標準出力はオンメモリに出している。(しかし使用していない)
  - ファイル出力を要求する場合、標準出力は使用されないはずなので特に問題は無いはず
  - そもそも標準出力をオンメモリに保持しなくなったので、現在ファイル出力を要求している問題も標準出力に変更できると思われる。
- 結果の比較は原則ファイル同士のLine by Lineで行われるので多くのメモリを必要としない
  - ただし、Settings#outputSource == Rawのの場合はオンメモリの比較になる。巨大なデータをtestcase.jsonに直接定義することはない(作成者側でコントロール可能)なので特に問題はないはず
- judgeも標準入力はファイル経由とした。出力はオンメモリだがjudgeの出力が巨大になることはないので問題ないはず

