### PR TITLE
Add shellMode to TestRunner

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codecheck",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "codecheck CLI",
   "main": "src/codecheck.js",
   "scripts": {

--- a/src/test_runner/settings.js
+++ b/src/test_runner/settings.js
@@ -31,6 +31,7 @@ const DEFAULT_TIMEOUT = 6000;
     "maxLines" : 20,
     "maxCharacters" : 300
   },
+  "shellMode": false,
   "timeout": 6000,
   "baseDirectory":  "test",
   "language": "ja"
@@ -59,6 +60,7 @@ const DEFAULT_TIMEOUT = 6000;
 - timeout -> 6000
 - baseDirectory -> "test",
 - language -> "ja"
+- shellMode -> false
  */
 
 function normalizeJson(json) {
@@ -131,6 +133,8 @@ class Settings {
 
   eps() { return this.json.eps; }
   hasEps() { return typeof(this.json.eps) === "number"; }
+
+  shellMode() { return Boolean(this.json.shellMode); }
 }
 
 module.exports = Settings;

--- a/test/testRunner.test.js
+++ b/test/testRunner.test.js
@@ -4,7 +4,7 @@ const codecheck = require("../src/codecheck");
 const assert = require('chai').assert;
 
 describe('TestRunner', function() {
-  this.timeout(60 * 1000);
+  this.timeout(120 * 1000);
 
   it('aojJudge.test.js', async () => {
     const app = codecheck.consoleApp("mocha").consoleOut(false);
@@ -53,6 +53,13 @@ describe('TestRunner', function() {
     assert.ok(result.stdout.some(v => v.indexOf("Participant's data: wxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqr") !== -1));
   });
 
+  it('shellMode.test.js', async () => {
+    const app = codecheck.consoleApp("mocha").consoleOut(false);
+    const result = await app.codecheck("-R", "tap", "test/test_runner/shellMode.test.js");
+    assert.ok(result.stdout.some(v => v.indexOf("# tests 130") !== -1));
+    assert.ok(result.stdout.some(v => v.indexOf("# pass 113") !== -1));
+  });
+
   it('testRunner.test.js', async () => {
     const app = codecheck.consoleApp("mocha").consoleOut(false);
     const result = await app.codecheck("-R", "tap", "test/test_runner/testRunner.test.js");
@@ -66,6 +73,6 @@ describe('TestRunner', function() {
     assert.ok(result.stdout.some(v => v.indexOf("# tests 4") !== -1));
     assert.ok(result.stdout.some(v => v.indexOf("# pass 2") !== -1));
     assert.ok(result.stdout.some(v => v.indexOf("Your application didn't finish in expected time") !== -1));
-    assert.ok(result.stdout.some(v => v.indexOf("Error: Timeout of 6000ms exceeded. ") !== -1));
+    assert.ok(result.stdout.some(v => v.indexOf("Error: Timeout of 11000ms exceeded. ") !== -1));
   });
 });

--- a/test/test_runner/shellMode.test.js
+++ b/test/test_runner/shellMode.test.js
@@ -1,0 +1,106 @@
+"use strict";
+
+const fs = require("fs");
+const codecheck = require("../../src/codecheck");
+
+describe("TestRunner", function() {
+  describe("input = arguments, output = stdout", function() {
+    describe("menial-attack - all pass(25/25", function() {
+      const settings = Object.assign({
+        shellMode: true,
+        baseDirectory: "test/test_runner/menial-attack/test",
+        language: "ja"
+      }, require("./menial-attack/test/settings.json"));
+      const testcases = require("./menial-attack/test/basic_testcases.json");
+      const runner = codecheck.testRunner(settings, "node test/test_runner/menial-attack/solution.js");
+
+      runner.runAll(testcases);
+    });
+
+    describe("menial-attack - partial pass(19/25)", function() {
+      const settings = Object.assign({
+        shellMode: true,
+        baseDirectory: "test/test_runner/menial-attack/test",
+        language: "ja"
+      }, require("./menial-attack/test/settings.json"));
+      const testcases = require("./menial-attack/test/basic_testcases.json");
+      const runner = codecheck.testRunner(settings, "node test/test_runner/menial-attack/solution.partial.js");
+
+      runner.runAll(testcases);
+    });
+  });
+
+  describe("input = stdin, output = stdout", function() {
+    describe("menial-attack - all pass(25/25)", function() {
+      const settings = Object.assign({
+        shellMode: true,
+        baseDirectory: "test/test_runner/menial-attack/test",
+        language: "ja"
+      }, require("./menial-attack/test/settings.stdin.json"));
+      const testcases = require("./menial-attack/test/basic_testcases.json");
+      const runner = codecheck.testRunner(settings, "node test/test_runner/menial-attack/solution.stdin.js");
+
+      runner.runAll(testcases);
+    });
+  });
+
+  describe("input = file, output = file", function() {
+    describe("menial-attack - all pass(25/25)", function() {
+      const settings = Object.assign({
+        shellMode: true,
+        baseDirectory: "test/test_runner/menial-attack/test",
+        language: "ja"
+      }, require("./menial-attack/test/settings.file.json"));
+      const testcases = require("./menial-attack/test/basic_testcases.json");
+      const runner = codecheck.testRunner(settings, "node test/test_runner/menial-attack/solution.file.js");
+
+      runner.runAll(testcases);
+    });
+
+  });
+
+  describe("with raw", function() {
+    describe("menial-attack - with raw - partial pass(19/25)", function() {
+      const settings = Object.assign({
+        shellMode: true,
+        language: "ja"
+      }, require("./menial-attack/test/settings.stdin.json"));
+      settings.input = {
+        type: "arguments",
+        source: "raw"
+      };
+      settings.output = {
+        type: "stdout",
+        source: "raw"
+      };
+      const testcases = require("./menial-attack/test/basic_testcases.json").map(v => {
+        const input = fs.readFileSync("./test/test_runner/menial-attack/test/" + v.input, "utf-8");
+        const output = fs.readFileSync("./test/test_runner/menial-attack/test/" + v.output, "utf-8");
+        return Object.assign({}, v, {
+          input: input,
+          output: output
+        });
+      });
+      const runner = codecheck.testRunner(settings, "node test/test_runner/menial-attack/solution.partial.js");
+
+      runner.runAll(testcases);
+    });
+
+  });
+
+  describe("with infinite loop", function() {
+    describe("menial-attack - infinite loop - all fail(5/5)", function() {
+      const settings = Object.assign({
+        shellMode: true,
+        baseDirectory: "test/test_runner/menial-attack/test",
+        language: "ja"
+      }, require("./menial-attack/test/settings.json"));
+      const testcases = require("./menial-attack/test/basic_testcases.json").slice(0, 5);
+      const runner = codecheck.testRunner(settings, "node test/infinite/infinite.js");
+
+      runner.runAll(testcases);
+    });
+
+  });
+
+});

--- a/test/test_runner/timeout.test.js
+++ b/test/test_runner/timeout.test.js
@@ -30,7 +30,7 @@ describe("Timeout", function() {
     output: "Hello"
   }, {
     description: "wait 8000ms",
-    input: "8000",
+    input: "12000",
     output: "Hello"
   }];
   const command = "node test/app/timeoutTest.js";


### PR DESCRIPTION
TestRunnerにshellModeを追加しました。

settings.jsonに

```
  "shellMode": true
```

というキーを追加するとshellModeでテストが実行されます。

## shellModeとは？
通常のモードでは環境変数APP_COMMANDで指定されているコマンド(`./a.out`とか`node main.js`とか）をNodeJSのprocessでキックして、標準入出力はすべてNodeJS側で制御しています。
巨大な入力ファイルはNodeJS側でファイルを読み込みながらprocessに流し込んでいるわけです。

一方のshellModeでは以下のようなシェルコマンドを生成してprocessキックします。

```
sh -c "cat test/01.in | ./a.out > answer.txt"
または
sh -c './a.out ”arg1" "arg2" "arg3"> answer.txt'
```

つまり、標準入出力の制御は全部シェルに任せています。これは通常モードに比べて圧倒的に高速です。

ただ、引数に「ダブルクォートが含まれていたらどうなるの？」とか、細かい部分がテストできていないのでshellModeをデフォルトにはしていません。(ていうか、ダブルクォート入りの引数は現在ちゃんと動かないと思います。)

ほとんどのテストはshellModeで実行可能だとは思いますが、当面shellModeを使う場合は、手作業でsettings.jsonにキーを追加してください。

@hamko review me